### PR TITLE
v3.0.0-beta.1

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
       - name: Dart version
         run: |
@@ -25,12 +25,12 @@ jobs:
         run: dart analyze --fatal-infos --fatal-warnings .
       - name: dependency_validator
         run: dart run dependency_validator
-      - name: Run tests (VM)
-        run: dart test --platform vm
-      - name: Run tests (Chrome)
-        run: dart test --platform chrome
-#      - name: dartdoc
-#        run: dartdoc --no-generate-docs
+      - name: Run tests (Chrome JS)
+        run: dart test --platform chrome --compiler dart2js
+      - name: Run tests (Chrome Wasm)
+        run: dart test --platform chrome --compiler dart2wasm
+      #      - name: dartdoc
+      #        run: dartdoc --no-generate-docs
       - name: dart pub publish --dry-run
         run: dart pub publish --dry-run
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 3.0.0-beta.1
+
+- Change to `dart:js_interop` (and package `js_interop_utils`).
+
+- CI: test with `dart2js` and `dart2wasm` (on Chrome).
+
+- dom_tools: ^3.0.0-beta.1
+- js_interop_utils: ^1.0.1
+
+- lints: ^5.1.1
+
 ## 2.0.4
 
 - sdk: '>=3.4.0 <4.0.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - CI: test with `dart2js` and `dart2wasm` (on Chrome).
 
 - dom_tools: ^3.0.0-beta.3
-- js_interop_utils: ^1.0.5
 
 - lints: ^5.1.1
 - test: ^1.25.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 - CI: test with `dart2js` and `dart2wasm` (on Chrome).
 
-- dom_tools: ^3.0.0-beta.1
-- js_interop_utils: ^1.0.1
+- dom_tools: ^3.0.0-beta.3
+- js_interop_utils: ^1.0.5
 
 - lints: ^5.1.1
+- test: ^1.25.15
 
 ## 2.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.0-beta.2
+
+- sdk: '>=3.6.0 <4.0.0'
+
+- dom_tools: ^3.0.0-beta.4
+
 ## 3.0.0-beta.1
 
 - Change to `dart:js_interop` (and package `js_interop_utils`).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 [![Code size](https://img.shields.io/github/languages/code-size/gmpassos/amdjs.dart?logo=github&logoColor=white)](https://github.com/gmpassos/amdjs.dart)
 [![License](https://img.shields.io/github/license/gmpassos/amdjs.dart?logo=open-source-initiative&logoColor=green)](https://github.com/gmpassos/amdjs.dart/blob/master/LICENSE)
 
-
 JavaScript AMD (Asynchronous Module Definition) Dart interoperability.  
 
 When using JS libraries that uses AMD (RequireJS), you need to call the JS function require() to correctly load
@@ -19,6 +18,12 @@ the library or unpredicted behaviors will happens.
 
 This Dart packages helps to transparently load JS libraries from Dart, using native AMD require(), when present, or just adding
 a `<script src="library.js"></script>` into DOM.
+
+
+### Package `dart:js_interop`
+
+Starting with version `3.0.0`, the `amdjs` package relies on the [js_interop_utils](https://pub.dev/packages/js_interop_utils) package and `dart:js_interop`,
+replacing the deprecated `dart:js` library (deprecated as of Dart `3.7.0+`).
 
 ## Usage
 

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -18,3 +18,4 @@ define_platforms:
         linux: firefox-esr
 
 platforms: [chrome]
+compilers: [dart2js, dart2wasm]

--- a/lib/amdjs.dart
+++ b/lib/amdjs.dart
@@ -1,3 +1,4 @@
-library amdjs;
+/// JavaScript AMD (Asynchronous Module Definition) Dart interoperability.
+library;
 
 export 'src/amdjs_base.dart';

--- a/lib/src/amdjs_base.dart
+++ b/lib/src/amdjs_base.dart
@@ -1,8 +1,32 @@
 import 'dart:async';
-import 'dart:js';
+import 'dart:js_interop_unsafe';
 
 import 'package:dom_tools/dom_tools.dart';
-import 'package:swiss_knife/swiss_knife.dart';
+
+@JS('define')
+external JSAny? get _jsDefine;
+
+@JS('require')
+external JSAny? get _jsRequire;
+
+extension type _RequireConfigPaths._(JSObject o) implements JSObject {
+  external _RequireConfigPaths({JSObject paths});
+
+  external JSObject get paths;
+}
+
+extension type _RequireConfigPackages._(JSObject o) implements JSObject {
+  external _RequireConfigPackages({JSArray<JSObject> packages});
+
+  external JSArray<JSObject> get packages;
+}
+
+@JS('require.config')
+external void _jsSetRequireConfig(JSObject config);
+
+@JS('require')
+external void _jsCallRequire(
+    JSArray<JSString> modules, JSFunction onSuccess, JSFunction onError);
 
 /// JavaScript AMD (Asynchronous Module Definition) Dart interoperability.
 class AMDJS {
@@ -16,86 +40,62 @@ class AMDJS {
     }
   }
 
-  static final LoadController _load = LoadController('AMDJS');
-
   /// Ensures that this class and JS interoperability is loaded. You don't need
   /// to call this function, since it's already called internally by the API.
+  ///
+  /// **Don't needed anymore (using package `dart:js_interop`).
+  /// Innocuous, always return `true`.**
+  @Deprecated("Don't needed anymore (using package `dart:js_interop`).")
   static Future<bool> load() {
-    return _load.load(() async {
-      var okJs = evalJS('''
-          
-          __AMDJS__isNativeImplementationPresent = function() {
-              var definedPresent = ((typeof define === 'function') && define.amd) ;
-              var requirePresent = (typeof require === 'function') ;
-              return definedPresent && requirePresent ;
-          }
-          
-          __AMDJS__requireModuleNative_byPath = function(name, path, globalName, callback) {
-              var conf = {
-                paths: {}
-              };
-              
-              conf['paths'][name] = path ;
-              
-              require.config(conf);
-              
-              require(
-                  [name] ,
-                  function(r) {
-                      if ( globalName != null ) {
-                        if ( r && !window[globalName] ) {
-                          window[globalName] = r ;
-                        }
-                      }
-                      
-                      callback(true) ;
-                  } ,
-                  function(err) {
-                      callback( ''+err ) ;
-                  }
-              );
-          }
-          
-          __AMDJS__requireModuleNative_byPackage = function(names, location, subPath, globalName, callback) {
-              var conf = { 
-                packages: [{
-                  name: names[0],
-                  location: location,
-                  main: subPath
-                }]
-              };
-              
-              require.config(conf);
-              
-              require(
-                  names ,
-                  function(r) {
-                      if ( globalName != null ) {
-                        if ( r && !window[globalName] ) {
-                          window[globalName] = r ;
-                        }
-                      }
-                      
-                      callback(true) ;
-                  } ,
-                  function(err) {
-                      callback( ''+err ) ;
-                  }
-              );
-          }
-      
-      ''');
-
-      return okJs != null;
-    });
+    return Future.value(true);
   }
 
-  /// Returns true if native JS AMD is detected:
-  static Future<bool> isNativeImplementationPresent() async {
-    await load();
-    var present =
-        context.callMethod('__AMDJS__isNativeImplementationPresent') as bool?;
-    return present ?? false;
+  static bool isNativeImplementationPresent() {
+    final definedPresent = _jsDefine.isA<JSFunction>();
+    final requirePresent = _jsRequire.isA<JSFunction>();
+    return definedPresent && requirePresent;
+  }
+
+  static void _callRequire(JSObject config, List<String> names,
+      String? globalName, void Function(dynamic) callback) {
+    _jsSetRequireConfig(config);
+
+    _jsCallRequire(
+      names.toJS,
+      (JSAny? r) {
+        if (globalName != null && r != null) {
+          var val = globalContext[globalName];
+          if (val == null || val.isUndefinedOrNull) {
+            globalContext[globalName] = r;
+          }
+        }
+        callback(true);
+      }.toJS,
+      (JSAny? err) {
+        callback(err.toString());
+      }.toJS,
+    );
+  }
+
+  static void requireModuleNativeByPath(String name, String path,
+      String? globalName, void Function(dynamic) callback) {
+    final config = _RequireConfigPaths(paths: {name: path}.toJSDeep);
+    _callRequire(config, [name], globalName, callback);
+  }
+
+  static void requireModuleNativeByPackage(List<String> names, String location,
+      String subPath, String? globalName, void Function(dynamic) callback) {
+    // Create the configuration object with packages
+    final config = _RequireConfigPackages(
+        packages: [
+      {
+        'name': names[0],
+        'location': location,
+        'main': subPath,
+      }.toJSDeep
+    ].toJS);
+
+    _callRequire(config, names, globalName, callback);
   }
 
   /// Tries to load a [module] using native AMD using [jsFullPath]. Is
@@ -105,9 +105,7 @@ class AMDJS {
   /// Throws [StateError] if native mode is not detected.
   static Future<bool> requireNativeByPath(String module, String jsFullPath,
       {String? globalJSVariableName}) async {
-    await load();
-
-    var nativePresent = await isNativeImplementationPresent();
+    var nativePresent = isNativeImplementationPresent();
 
     if (!nativePresent) {
       throw StateError('AMD native implementation not present');
@@ -119,16 +117,11 @@ class AMDJS {
 
     var completer = Completer<bool>();
 
-    context.callMethod('__AMDJS__requireModuleNative_byPath', [
-      module,
-      jsFullPath,
-      globalJSVariableName,
-      (r) {
-        var ok = r == true;
-        _log(true, "Module '$module' loaded[by path]> ok: $ok");
-        completer.complete(ok);
-      }
-    ]) as bool?;
+    requireModuleNativeByPath(module, jsFullPath, globalJSVariableName, (r) {
+      var ok = r == true;
+      _log(true, "Module '$module' loaded[by path]> ok: $ok");
+      completer.complete(ok);
+    });
 
     return completer.future;
   }
@@ -141,9 +134,7 @@ class AMDJS {
   static Future<bool> requireNativeByPackage(
       List<String> modules, String jsLocation, jsSubPath,
       {String? globalJSVariableName}) async {
-    await load();
-
-    var nativePresent = await isNativeImplementationPresent();
+    var nativePresent = isNativeImplementationPresent();
 
     if (!nativePresent) {
       throw StateError('AMD native implementation not present');
@@ -155,17 +146,12 @@ class AMDJS {
 
     var completer = Completer<bool>();
 
-    context.callMethod('__AMDJS__requireModuleNative_byPackage', [
-      JsObject.jsify(modules),
-      jsLocation,
-      jsSubPath,
-      globalJSVariableName,
-      (r) {
-        var ok = r == true;
-        _log(true, "Modules '$modules' loaded[by package]> ok: $ok");
-        completer.complete(ok);
-      }
-    ]) as bool?;
+    requireModuleNativeByPackage(
+        modules, jsLocation, jsSubPath, globalJSVariableName, (r) {
+      var ok = r == true;
+      _log(true, "Modules '$modules' loaded[by package]> ok: $ok");
+      completer.complete(ok);
+    });
 
     return completer.future;
   }
@@ -187,7 +173,7 @@ class AMDJS {
 
     modulesList.removeWhere((e) => e.isEmpty);
 
-    if (await isNativeImplementationPresent()) {
+    if (isNativeImplementationPresent()) {
       bool requireOK;
 
       if (jsFullPath != null && jsFullPath.isNotEmpty) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,17 @@
 name: amdjs
 description: JavaScript AMD (Asynchronous Module Definition) Dart interoperability.
-version: 2.0.4
+version: 3.0.0-beta.1
 homepage: https://github.com/gmpassos/amdjs.dart
 
 environment:
   sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
-  dom_tools: ^2.3.2
-  swiss_knife: ^3.2.3
+  dom_tools: ^3.0.0-beta.1
+  js_interop_utils: ^1.0.1
 
 dev_dependencies:
-  lints: ^4.0.0
+  lints: ^5.1.1
   test: ^1.25.14
   dependency_validator: ^4.1.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
 
 dependencies:
   dom_tools: ^3.0.0-beta.3
-  js_interop_utils: ^1.0.5
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,12 +7,12 @@ environment:
   sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
-  dom_tools: ^3.0.0-beta.1
-  js_interop_utils: ^1.0.1
+  dom_tools: ^3.0.0-beta.3
+  js_interop_utils: ^1.0.5
 
 dev_dependencies:
   lints: ^5.1.1
-  test: ^1.25.14
+  test: ^1.25.15
   dependency_validator: ^4.1.2
 
 #dependency_overrides:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: amdjs
 description: JavaScript AMD (Asynchronous Module Definition) Dart interoperability.
-version: 3.0.0-beta.1
+version: 3.0.0-beta.2
 homepage: https://github.com/gmpassos/amdjs.dart
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
-  dom_tools: ^3.0.0-beta.3
+  dom_tools: ^3.0.0-beta.4
 
 dev_dependencies:
   lints: ^5.1.1

--- a/test/amdjs_browser_test.dart
+++ b/test/amdjs_browser_test.dart
@@ -10,7 +10,7 @@ void main() {
     setUp(() {});
 
     test('isNativeImplementationPresent', () async {
-      expect(await AMDJS.isNativeImplementationPresent(), equals(false));
+      expect(AMDJS.isNativeImplementationPresent(), equals(false));
     });
 
     test('libFoo', () async {


### PR DESCRIPTION
- Change to `dart:js_interop` (and package `js_interop_utils`).

- CI: test with `dart2js` and `dart2wasm` (on Chrome).

- dom_tools: ^3.0.0-beta.1
- js_interop_utils: ^1.0.1

- lints: ^5.1.1